### PR TITLE
Make IImageService methods async with optional CancellationToken

### DIFF
--- a/src/Common.Media/Drawing/Services/Abstractions/IImageColorService.cs
+++ b/src/Common.Media/Drawing/Services/Abstractions/IImageColorService.cs
@@ -14,19 +14,22 @@ public interface IImageColorService
     /// <param name="input">The image file.</param>
     /// <param name="x">The x-coordinate of the pixel.</param>
     /// <param name="y">The y-coordinate of the pixel.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The color of the specified pixel.</returns>
-    Color GetPixelColor(IImageFile input, int x, int y);
+    Task<Color> GetPixelColor(IImageFile input, int x, int y, CancellationToken cancellationToken = default);
     /// <summary>
     /// Makes the specified color in the input image transparent.
     /// </summary>
     /// <param name="input">The source image file.</param>
     /// <param name="color">The color to make transparent (optional, defaults to light gray).</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The image file with transparency applied.</returns>
-    IImageFile MakeTransparent(IImageFile input, Color? color = null);
+    Task<IImageFile> MakeTransparent(IImageFile input, Color? color = null, CancellationToken cancellationToken = default);
     /// <summary>
     /// Removes the alpha channel from the input image, replacing transparent pixels with a solid color (typically white).
     /// </summary>
     /// <param name="input">The source image file to process.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The image file with alpha transparency removed.</returns>
-    IImageFile MakeOpaque(IImageFile input);
+    Task<IImageFile> MakeOpaque(IImageFile input, CancellationToken cancellationToken = default);
 }

--- a/src/Common.Media/Drawing/Services/Abstractions/IImageCreator.cs
+++ b/src/Common.Media/Drawing/Services/Abstractions/IImageCreator.cs
@@ -1,15 +1,15 @@
-﻿using Regira.Media.Drawing.Models.Abstractions;
+using Regira.Media.Drawing.Models.Abstractions;
 
 namespace Regira.Media.Drawing.Services.Abstractions;
 
 public interface IImageCreator
 {
     public bool CanCreate(object input);
-    public IImageFile? Create(object input);
+    public Task<IImageFile?> Create(object input, CancellationToken cancellationToken = default);
 }
 public interface IImageCreator<in T> : IImageCreator
     where T : notnull
 {
     public bool CanCreate(T input);
-    public IImageFile? Create(T input);
+    public Task<IImageFile?> Create(T input, CancellationToken cancellationToken = default);
 }

--- a/src/Common.Media/Drawing/Services/Abstractions/IImageDrawService.cs
+++ b/src/Common.Media/Drawing/Services/Abstractions/IImageDrawService.cs
@@ -16,19 +16,22 @@ public interface IImageDrawService
     /// <param name="size">The size of the image.</param>
     /// <param name="backgroundColor">The background color (optional).</param>
     /// <param name="format">The image format (optional).</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The created image file.</returns>
-    IImageFile Create(ImageSize size, Color? backgroundColor = null, ImageFormat? format = null);
+    Task<IImageFile> Create(ImageSize size, Color? backgroundColor = null, ImageFormat? format = null, CancellationToken cancellationToken = default);
     /// <summary>
     /// Creates an image containing text, using the specified label options.
     /// </summary>
     /// <param name="options">The label image options (optional).</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The created text image file.</returns>
-    IImageFile CreateTextImage(LabelImageOptions? options = null);
+    Task<IImageFile> CreateTextImage(LabelImageOptions? options = null, CancellationToken cancellationToken = default);
     /// <summary>
     /// Draws multiple images onto a target image or a new canvas, with optional DPI.
     /// </summary>
     /// <param name="items">The collection of images to add.</param>
     /// <param name="target">The target image file (optional).</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The resulting image file with all images drawn.</returns>
-    IImageFile Draw(IEnumerable<ImageLayer> items, IImageFile? target = null);
+    Task<IImageFile> Draw(IEnumerable<ImageLayer> items, IImageFile? target = null, CancellationToken cancellationToken = default);
 }

--- a/src/Common.Media/Drawing/Services/Abstractions/IImageFormatService.cs
+++ b/src/Common.Media/Drawing/Services/Abstractions/IImageFormatService.cs
@@ -12,13 +12,15 @@ public interface IImageFormatService
     /// Determines the <see cref="ImageFormat"/> of the given <see cref="IImageFile"/>.
     /// </summary>
     /// <param name="input">The image file to inspect.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The detected image format.</returns>
-    ImageFormat GetFormat(IImageFile input);
+    Task<ImageFormat> GetFormat(IImageFile input, CancellationToken cancellationToken = default);
     /// <summary>
     /// Converts an image to a different format.
     /// </summary>
     /// <param name="input">The source image file.</param>
     /// <param name="targetFormat">The desired image format.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The converted image file.</returns>
-    IImageFile ChangeFormat(IImageFile input, ImageFormat targetFormat);
+    Task<IImageFile> ChangeFormat(IImageFile input, ImageFormat targetFormat, CancellationToken cancellationToken = default);
 }

--- a/src/Common.Media/Drawing/Services/Abstractions/IImageParsingService.cs
+++ b/src/Common.Media/Drawing/Services/Abstractions/IImageParsingService.cs
@@ -15,27 +15,31 @@ public interface IImageParsingService
     /// Returns null if the stream is null or cannot be decoded.
     /// </summary>
     /// <param name="stream">The input stream containing image data.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The parsed image file, or null if parsing fails.</returns>
-    IImageFile? Parse(Stream stream);
+    Task<IImageFile?> Parse(Stream? stream, CancellationToken cancellationToken = default);
     /// <summary>
     /// Parses an image from a byte array and returns an <see cref="IImageFile"/> representation.
     /// Returns null if the byte array is null or cannot be decoded.
     /// </summary>
     /// <param name="bytes">The input byte array containing image data.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The parsed image file, or null if parsing fails.</returns>
-    IImageFile? Parse(byte[] bytes);
+    Task<IImageFile?> Parse(byte[]? bytes, CancellationToken cancellationToken = default);
     /// <summary>
     /// Parses an image from raw pixel bytes, size, and optional format, returning an <see cref="IImageFile"/>.
     /// </summary>
     /// <param name="rawBytes">The raw pixel data.</param>
     /// <param name="size">The dimensions of the image.</param>
     /// <param name="format">The image format (optional, defaults to JPEG).</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The parsed image file, or null if parsing fails.</returns>
-    IImageFile? Parse(byte[] rawBytes, ImageSize size, ImageFormat? format = null);
+    Task<IImageFile?> Parse(byte[] rawBytes, ImageSize size, ImageFormat? format = null, CancellationToken cancellationToken = default);
     /// <summary>
     /// Parses an image from an <see cref="IMemoryFile"/> by using its stream or byte content.
     /// </summary>
     /// <param name="file">The memory file containing image data.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The parsed image file, or null if parsing fails.</returns>
-    IImageFile? Parse(IMemoryFile file);
+    Task<IImageFile?> Parse(IMemoryFile file, CancellationToken cancellationToken = default);
 }

--- a/src/Common.Media/Drawing/Services/Abstractions/IImageTransformService.cs
+++ b/src/Common.Media/Drawing/Services/Abstractions/IImageTransformService.cs
@@ -13,24 +13,27 @@ public interface IImageTransformService
     /// Gets the dimensions (width and height) of the input image.
     /// </summary>
     /// <param name="input">The image file.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The size of the image as a <see cref="ImageSize"/>.</returns>
-    ImageSize GetDimensions(IImageFile input);
+    Task<ImageSize> GetDimensions(IImageFile input, CancellationToken cancellationToken = default);
     /// <summary>
     /// Resizes the input image to the specified size, with optional quality.
     /// </summary>
     /// <param name="input">The source image file.</param>
     /// <param name="wantedSize">The desired size.</param>
     /// <param name="quality">The quality of the resize operation (default 100).</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The resized image file.</returns>
-    IImageFile Resize(IImageFile input, ImageSize wantedSize, int quality = 100);
+    Task<IImageFile> Resize(IImageFile input, ImageSize wantedSize, int quality = 100, CancellationToken cancellationToken = default);
     /// <summary>
     /// Resizes the input image to the exact specified size, ignoring aspect ratio, with optional quality.
     /// </summary>
     /// <param name="input">The source image file.</param>
     /// <param name="size">The target size.</param>
     /// <param name="quality">The quality of the resize operation (default 100).</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The resized image file.</returns>
-    IImageFile ResizeFixed(IImageFile input, ImageSize size, int quality = 100);
+    Task<IImageFile> ResizeFixed(IImageFile input, ImageSize size, int quality = 100, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Crops the specified rectangular region from the input image.
@@ -39,8 +42,9 @@ public interface IImageTransformService
     /// <param name="rect">
     /// The rectangular region to crop, defined by its top, left, bottom, and right margins.
     /// </param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The cropped image file.</returns>
-    IImageFile CropRectangle(IImageFile input, ImageEdgeOffset rect);
+    Task<IImageFile> CropRectangle(IImageFile input, ImageEdgeOffset rect, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Rotates the input image by the specified angle, with an optional background color.
@@ -48,18 +52,21 @@ public interface IImageTransformService
     /// <param name="input">The source image file.</param>
     /// <param name="degrees"></param>
     /// <param name="background">The background color to use for empty areas (optional).</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The rotated image file.</returns>
-    IImageFile Rotate(IImageFile input, int degrees, Color? background = null);
+    Task<IImageFile> Rotate(IImageFile input, int degrees, Color? background = null, CancellationToken cancellationToken = default);
     /// <summary>
     /// Flips the input image horizontally.
     /// </summary>
     /// <param name="input">The source image file.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The horizontally flipped image file.</returns>
-    IImageFile FlipHorizontal(IImageFile input);
+    Task<IImageFile> FlipHorizontal(IImageFile input, CancellationToken cancellationToken = default);
     /// <summary>
     /// Flips the input image vertically.
     /// </summary>
     /// <param name="input">The source image file.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>The vertically flipped image file.</returns>
-    IImageFile FlipVertical(IImageFile input);
+    Task<IImageFile> FlipVertical(IImageFile input, CancellationToken cancellationToken = default);
 }

--- a/src/Common.Media/Drawing/Services/Abstractions/ImageCreatorBase.cs
+++ b/src/Common.Media/Drawing/Services/Abstractions/ImageCreatorBase.cs
@@ -1,4 +1,4 @@
-﻿using Regira.Media.Drawing.Models.Abstractions;
+using Regira.Media.Drawing.Models.Abstractions;
 
 namespace Regira.Media.Drawing.Services.Abstractions;
 
@@ -9,10 +9,10 @@ public abstract class ImageCreatorBase<T> : IImageCreator<T>
         => input is T item && CanCreate(item);
     public virtual bool CanCreate(T input) => true;
 
-    IImageFile? IImageCreator.Create(object input)
-        => TryCreate((T)input);
-    protected virtual IImageFile? TryCreate(T input)
-        => CanCreate(input) ? Create(input) : null;
+    Task<IImageFile?> IImageCreator.Create(object input, CancellationToken cancellationToken)
+        => TryCreate((T)input, cancellationToken);
+    protected virtual Task<IImageFile?> TryCreate(T input, CancellationToken cancellationToken)
+        => CanCreate(input) ? Create(input, cancellationToken) : Task.FromResult<IImageFile?>(null);
 
-    public abstract IImageFile? Create(T input);
+    public abstract Task<IImageFile?> Create(T input, CancellationToken cancellationToken = default);
 }

--- a/src/Common.Media/Drawing/Services/AggregateImageCreator.cs
+++ b/src/Common.Media/Drawing/Services/AggregateImageCreator.cs
@@ -18,7 +18,7 @@ public class AggregateImageCreator : ImageCreatorBase<AggregateImageOptions>
     public static AggregateImageCreator Create(IImageService service, IEnumerable<IImageCreator> imageCreators)
         => new(service, imageCreators);
 
-    public override IImageFile Create(AggregateImageOptions input)
+    public override async Task<IImageFile?> Create(AggregateImageOptions input, CancellationToken cancellationToken = default)
     {
         var builder = new ImageBuilder(_service, _imageCreators);
 
@@ -28,6 +28,6 @@ public class AggregateImageCreator : ImageCreatorBase<AggregateImageOptions>
         }
 
         builder.Add(input.ImageLayers.ToArray());
-        return builder.Build();
+        return await builder.Build(cancellationToken);
     }
 }

--- a/src/Common.Media/Drawing/Services/CanvasImageCreator.cs
+++ b/src/Common.Media/Drawing/Services/CanvasImageCreator.cs
@@ -6,6 +6,6 @@ namespace Regira.Media.Drawing.Services;
 
 public class CanvasImageCreator(IImageService service) : ImageCreatorBase<CanvasImageOptions>
 {
-    public override IImageFile Create(CanvasImageOptions input) 
-        => service.Create(input.Size, input.BackgroundColor, input.ImageFormat);
+    public override async Task<IImageFile?> Create(CanvasImageOptions input, CancellationToken cancellationToken = default)
+        => await service.Create(input.Size, input.BackgroundColor, input.ImageFormat, cancellationToken);
 }

--- a/src/Common.Media/Drawing/Services/ImageBuilder.cs
+++ b/src/Common.Media/Drawing/Services/ImageBuilder.cs
@@ -86,25 +86,28 @@ public class ImageBuilder(IImageService service, IEnumerable<IImageCreator> imag
     /// <summary>
     /// Builds and returns the resulting <see cref="IImageFile"/> by combining the base layer and additional image layers.
     /// </summary>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>
     /// The constructed <see cref="IImageFile"/> containing the combined image layers.
     /// </returns>
     /// <exception cref="Exception">
     /// Thrown when the base layer cannot be converted into an <see cref="IImageFile"/>.
     /// </exception>
-    public IImageFile Build()
+    public async Task<IImageFile> Build(CancellationToken cancellationToken = default)
     {
         var target = _target != null
-            ? _imageCreators.GetImageFile(_target) ?? throw new Exception($"Could not create IImageFile from {_target.GetType()}")
+            ? await _imageCreators.GetImageFile(_target, cancellationToken) ?? throw new Exception($"Could not create IImageFile from {_target.GetType()}")
             : null;
 
-        var result = _items.Select(ToImageLayer)
-            .Aggregate(
-                target,
-                (img, imageLayer) => service.Draw([imageLayer], img)
-            )!;
+        IImageFile? result = target;
+        foreach (var item in _items)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var imageLayer = await ToImageLayer(item, cancellationToken);
+            result = await service.Draw([imageLayer], result, cancellationToken);
+        }
 
-        return result;
+        return result!;
     }
 
     /// <summary>
@@ -113,22 +116,26 @@ public class ImageBuilder(IImageService service, IEnumerable<IImageCreator> imag
     /// <param name="item">
     /// The <see cref="IImageLayer"/> instance to be converted.
     /// </param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>
     /// An <see cref="ImageLayer"/> instance containing the source and options from the provided <paramref name="item"/>.
     /// </returns>
     /// <exception cref="Exception">
     /// Thrown when the source object of the provided <paramref name="item"/> cannot be converted into an <see cref="IImageFile"/>.
     /// </exception>
-    protected ImageLayer ToImageLayer(IImageLayer item)
+    protected async Task<ImageLayer> ToImageLayer(IImageLayer item, CancellationToken cancellationToken = default)
     {
         if (item is ImageLayer imageLayer)
         {
             return imageLayer;
         }
 
+        var source = await _imageCreators.GetImageFile(item, cancellationToken)
+                     ?? throw new Exception($"Could not create IImageFile from {item.Source.GetType()}");
+
         return new ImageLayer
         {
-            Source = _imageCreators.GetImageFile(item) ?? throw new Exception($"Could not create IImageFile from {item.Source.GetType()}"),
+            Source = source,
             Options = item.Options
         };
     }

--- a/src/Common.Media/Drawing/Services/LabelImageCreator.cs
+++ b/src/Common.Media/Drawing/Services/LabelImageCreator.cs
@@ -6,6 +6,6 @@ namespace Regira.Media.Drawing.Services;
 
 public class LabelImageCreator(IImageService service) : ImageCreatorBase<LabelImageOptions>
 {
-    public override IImageFile Create(LabelImageOptions input)
-        => service.CreateTextImage(input);
+    public override async Task<IImageFile?> Create(LabelImageOptions input, CancellationToken cancellationToken = default)
+        => await service.CreateTextImage(input, cancellationToken);
 }

--- a/src/Common.Media/Drawing/Utilities/DrawImageUtility.cs
+++ b/src/Common.Media/Drawing/Utilities/DrawImageUtility.cs
@@ -24,12 +24,18 @@ public static class DrawImageUtility
     /// <param name="input">
     /// The input object of type <typeparamref name="T"/> used to create the <see cref="IImageFile"/>.
     /// </param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>
     /// An <see cref="IImageFile"/> instance if a suitable <see cref="IImageCreator"/> is found and creation succeeds; otherwise, <c>null</c>.
     /// </returns>
-    public static IImageFile? Create<T>(this IEnumerable<IImageCreator> services, T input)
+    public static Task<IImageFile?> Create<T>(this IEnumerable<IImageCreator> services, T input, CancellationToken cancellationToken = default)
         where T : class
-        => services.FirstOrDefault(s => s.CanCreate(input))?.Create(input);
+    {
+        var creator = services.FirstOrDefault(s => s.CanCreate(input));
+        return creator is null
+            ? Task.FromResult<IImageFile?>(null)
+            : creator.Create(input, cancellationToken);
+    }
     /// <summary>
     /// Retrieves an <see cref="IImageFile"/> instance from the provided <paramref name="item"/> or creates one using the available <paramref name="services"/>.
     /// </summary>
@@ -39,11 +45,14 @@ public static class DrawImageUtility
     /// <param name="item">
     /// The <see cref="IImageLayer"/> instance containing the source object to retrieve or create the <see cref="IImageFile"/>.
     /// </param>
+    /// <param name="cancellationToken">A token that can be used to cancel the operation.</param>
     /// <returns>
     /// An <see cref="IImageFile"/> instance if successfully retrieved or created; otherwise, <c>null</c>.
     /// </returns>
-    public static IImageFile? GetImageFile(this IEnumerable<IImageCreator> services, IImageLayer item)
-        => item.Source as IImageFile ?? services.Create(item.Source);
+    public static Task<IImageFile?> GetImageFile(this IEnumerable<IImageCreator> services, IImageLayer item, CancellationToken cancellationToken = default)
+        => item.Source is IImageFile imageFile
+            ? Task.FromResult<IImageFile?>(imageFile)
+            : services.Create(item.Source, cancellationToken);
 
     /// <summary>
     /// Calculates the coordinates for positioning an image within a target area based on the provided options, target size, image size, and DPI.

--- a/src/Common.Office/Barcodes/Drawing/BarcodeImageCreator.cs
+++ b/src/Common.Office/Barcodes/Drawing/BarcodeImageCreator.cs
@@ -6,6 +6,6 @@ using Regira.Office.Barcodes.Models;
 namespace Regira.Office.Barcodes.Drawing;
 public class BarcodeImageCreator(IBarcodeWriter barcodeWriter) : ImageCreatorBase<BarcodeInput>
 {
-    public override IImageFile Create(BarcodeInput input)
-        => barcodeWriter.Create(input).GetAwaiter().GetResult();
+    public override async Task<IImageFile?> Create(BarcodeInput input, CancellationToken cancellationToken = default)
+        => await barcodeWriter.Create(input);
 }

--- a/src/Common.Office/PDF/Drawing/PdfImageCreator.cs
+++ b/src/Common.Office/PDF/Drawing/PdfImageCreator.cs
@@ -7,13 +7,13 @@ namespace Regira.Office.PDF.Drawing;
 
 public class PdfImageCreator(IPdfToImageService service, IPdfSplitter splitter) : ImageCreatorBase<PdfToImageLayerOptions>
 {
-    public override IImageFile? Create(PdfToImageLayerOptions input)
+    public override async Task<IImageFile?> Create(PdfToImageLayerOptions input, CancellationToken cancellationToken = default)
     {
         var page = input.Page ?? 1;
-        var pageCount = splitter.GetPageCount(input.File).GetAwaiter().GetResult();
+        var pageCount = await splitter.GetPageCount(input.File);
         var singlePagePdf = pageCount > 1
-            ? splitter.Split(input.File, [new PdfSplitRange { Start = page, End = page }]).GetAwaiter().GetResult().Single()
+            ? (await splitter.Split(input.File, [new PdfSplitRange { Start = page, End = page }])).Single()
             : input.File;
-        return service.ToImages(singlePagePdf, input.ToPdfToImageOptions()).GetAwaiter().GetResult().SingleOrDefault();
+        return (await service.ToImages(singlePagePdf, input.ToPdfToImageOptions())).SingleOrDefault();
     }
 }

--- a/src/Common.Office/Word/Drawing/WordImageCreator.cs
+++ b/src/Common.Office/Word/Drawing/WordImageCreator.cs
@@ -6,9 +6,10 @@ namespace Regira.Office.Word.Drawing;
 
 public class WordImageCreator(IWordToImagesService service) : ImageCreatorBase<WordToImageLayerOptions>
 {
-    public override IImageFile? Create(WordToImageLayerOptions input)
+    public override async Task<IImageFile?> Create(WordToImageLayerOptions input, CancellationToken cancellationToken = default)
     {
-        return service.ToImages(input.ToWordTemplateInput()).GetAwaiter().GetResult()
+        var images = await service.ToImages(input.ToWordTemplateInput());
+        return images
             .Skip((input.Page ?? 1) - 1)
             .FirstOrDefault();
     }

--- a/src/Drawing.GDI/Services/ImageService.cs
+++ b/src/Drawing.GDI/Services/ImageService.cs
@@ -24,34 +24,44 @@ namespace Regira.Drawing.GDI.Services;
 /// This service supports various image formats defined in the <see cref="ImageFormat"/> enumeration and 
 /// works with image files represented by the <see cref="IImageFile"/> interface. It also provides utility 
 /// methods for creating, drawing, and modifying images.
+/// 
+/// All operations are exposed as <c>Task</c>-returning methods to enable async usage and cancellation, but the underlying
+/// GDI+ APIs are synchronous; the work is performed inline and wrapped via <see cref="Task.FromResult{T}"/>. Callers
+/// that need to offload work can do so with <see cref="Task.Run(System.Action)"/>.
 /// </remarks>
 public class ImageService : IImageService
 {
     /// <inheritdoc/>
-    public IImageFile? Parse(Stream? stream)
+    public Task<IImageFile?> Parse(Stream? stream, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (stream == null)
         {
-            return null;
+            return Task.FromResult<IImageFile?>(null);
         }
 
         using var img = Image.FromStream(stream);
-        return img.ToImageFile(img.RawFormat);
+        return Task.FromResult<IImageFile?>(img.ToImageFile(img.RawFormat));
     }
     /// <inheritdoc/>
-    public IImageFile? Parse(byte[]? bytes)
+    public Task<IImageFile?> Parse(byte[]? bytes, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (bytes == null)
         {
-            return null;
+            return Task.FromResult<IImageFile?>(null);
         }
 
         using var stream = new MemoryStream(bytes);
-        return Parse(stream);
+        return Parse(stream, cancellationToken);
     }
     /// <inheritdoc/>
-    public IImageFile Parse(byte[] rawBytes, ImageSize size, ImageFormat? format = null)
+    public Task<IImageFile?> Parse(byte[] rawBytes, ImageSize size, ImageFormat? format = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var bmp = new Bitmap(size.Width, size.Height, PixelFormat.Format32bppArgb);
         var rect = new Rectangle(0, 0, bmp.Width, bmp.Height);
 
@@ -60,118 +70,149 @@ public class ImageService : IImageService
 
         Marshal.Copy(rawBytes, 0, pNative, rawBytes.Length);
         bmp.UnlockBits(bmpData);
-        return bmp.ToImageFile((format ?? ImageFormat.Jpeg).ToGdiImageFormat());
+        return Task.FromResult<IImageFile?>(bmp.ToImageFile((format ?? ImageFormat.Jpeg).ToGdiImageFormat()));
     }
     /// <inheritdoc/>
-    public IImageFile? Parse(IMemoryFile file) => file.HasStream() ? Parse(file.Stream) : Parse(file.GetBytes());
+    public Task<IImageFile?> Parse(IMemoryFile file, CancellationToken cancellationToken = default) =>
+        file.HasStream() ? Parse(file.Stream, cancellationToken) : Parse(file.GetBytes(), cancellationToken);
 
     /// <inheritdoc/>
-    public ImageFormat GetFormat(IImageFile input)
+    public Task<ImageFormat> GetFormat(IImageFile input, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
-        return img.RawFormat.ToImageFormat();
+        return Task.FromResult(img.RawFormat.ToImageFormat());
     }
     /// <inheritdoc/>
-    public IImageFile ChangeFormat(IImageFile input, ImageFormat targetFormat)
+    public Task<IImageFile> ChangeFormat(IImageFile input, ImageFormat targetFormat, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
         using var convertedImg = GdiUtility.ChangeFormat(img, targetFormat.ToGdiImageFormat());
-        return convertedImg.ToImageFile(targetFormat.ToGdiImageFormat());
+        return Task.FromResult<IImageFile>(convertedImg.ToImageFile(targetFormat.ToGdiImageFormat()));
     }
 
     /// <inheritdoc/>
-    public IImageFile CropRectangle(IImageFile input, ImageEdgeOffset rect)
+    public Task<IImageFile> CropRectangle(IImageFile input, ImageEdgeOffset rect, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
         var (coordinate, size) = DrawImageUtility.ToPointSize(rect, new ImageSize(img.Width, img.Height));
         var gdiRectangle = new Rectangle(coordinate.X, coordinate.Y, size.Width, size.Height);
         using var cropped = GdiUtility.CropRectangle(img, gdiRectangle);
-        return cropped.ToImageFile(img.RawFormat);
+        return Task.FromResult<IImageFile>(cropped.ToImageFile(img.RawFormat));
     }
 
     /// <inheritdoc/>
-    public ImageSize GetDimensions(IImageFile input)
+    public Task<ImageSize> GetDimensions(IImageFile input, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
-        return new ImageSize(img.Width, img.Height);
+        return Task.FromResult(new ImageSize(img.Width, img.Height));
     }
     /// <inheritdoc/>
-    public IImageFile Resize(IImageFile input, ImageSize wantedSize, int quality = 100)
+    public Task<IImageFile> Resize(IImageFile input, ImageSize wantedSize, int quality = 100, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
         using var resized = GdiUtility.Resize(img, new Size(wantedSize.Width, wantedSize.Height));
-        return resized.ToImageFile(img.RawFormat);
+        return Task.FromResult<IImageFile>(resized.ToImageFile(img.RawFormat));
     }
     /// <inheritdoc/>
-    public IImageFile ResizeFixed(IImageFile input, ImageSize size, int quality = 100)
+    public Task<IImageFile> ResizeFixed(IImageFile input, ImageSize size, int quality = 100, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
         using var resized = GdiUtility.ResizeFixed(img, new Size(size.Width, size.Height));
-        return resized.ToImageFile(img.RawFormat);
+        return Task.FromResult<IImageFile>(resized.ToImageFile(img.RawFormat));
     }
 
     /// <inheritdoc/>
-    public IImageFile Rotate(IImageFile input, int degrees, Color? background = null)
+    public Task<IImageFile> Rotate(IImageFile input, int degrees, Color? background = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
         using var rotated = GdiUtility.Rotate(img, degrees, background?.ToGdiColor());
-        return rotated.ToImageFile(img.RawFormat);
+        return Task.FromResult<IImageFile>(rotated.ToImageFile(img.RawFormat));
     }
     /// <inheritdoc/>
-    public IImageFile FlipHorizontal(IImageFile input)
+    public Task<IImageFile> FlipHorizontal(IImageFile input, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
         using var flipped = GdiUtility.FlipHorizontal(img);
-        return flipped.ToImageFile(img.RawFormat);
+        return Task.FromResult<IImageFile>(flipped.ToImageFile(img.RawFormat));
     }
     /// <inheritdoc/>
-    public IImageFile FlipVertical(IImageFile input)
+    public Task<IImageFile> FlipVertical(IImageFile input, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
         using var flipped = GdiUtility.FlipVertical(img);
-        return flipped.ToImageFile(img.RawFormat);
+        return Task.FromResult<IImageFile>(flipped.ToImageFile(img.RawFormat));
     }
 
     /// <inheritdoc/>
-    public Color GetPixelColor(IImageFile input, int x, int y)
+    public Task<Color> GetPixelColor(IImageFile input, int x, int y, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
-        return GdiUtility.GetPixelColor(img, x, y).ToColor();
+        return Task.FromResult(GdiUtility.GetPixelColor(img, x, y).ToColor());
     }
     /// <inheritdoc/>
-    public IImageFile MakeTransparent(IImageFile input, Color? color = null)
+    public Task<IImageFile> MakeTransparent(IImageFile input, Color? color = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         color ??= new Color(245, 245, 245);
         using var img = input.ToBitmap();
         using var target = GdiUtility.MakeTransparent(img, color.Value.ToGdiColor());
-        return target.ToImageFile(System.Drawing.Imaging.ImageFormat.Png);
+        return Task.FromResult<IImageFile>(target.ToImageFile(System.Drawing.Imaging.ImageFormat.Png));
     }
     /// <inheritdoc/>
-    public IImageFile MakeOpaque(IImageFile input)
+    public Task<IImageFile> MakeOpaque(IImageFile input, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
         using var target = GdiUtility.ChangeOpacity(img, 1);
-        return target.ToImageFile(img.RawFormat);
+        return Task.FromResult<IImageFile>(target.ToImageFile(img.RawFormat));
     }
 
     /// <inheritdoc/>
-    public IImageFile Create(ImageSize size, Color? backgroundColor = null, ImageFormat? format = null)
+    public Task<IImageFile> Create(ImageSize size, Color? backgroundColor = null, ImageFormat? format = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = GdiUtility.Create(size.ToGdiSize(), (backgroundColor ?? ImageDefaults.BackgroundColor).ToGdiColor(), (format ?? ImageDefaults.Format).ToGdiImageFormat());
-        return img.ToImageFile(img.RawFormat);
+        return Task.FromResult<IImageFile>(img.ToImageFile(img.RawFormat));
     }
     /// <inheritdoc/>
-    public IImageFile CreateTextImage(LabelImageOptions? options = null)
+    public Task<IImageFile> CreateTextImage(LabelImageOptions? options = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = GdiUtility.CreateTextImage(options);
-        return img.ToImageFile(img.RawFormat);
+        return Task.FromResult<IImageFile>(img.ToImageFile(img.RawFormat));
     }
     /// <inheritdoc/>
-    public IImageFile Draw(IEnumerable<ImageLayer> imageLayers, IImageFile? target = null)
+    public Task<IImageFile> Draw(IEnumerable<ImageLayer> imageLayers, IImageFile? target = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var imagesCollection = imageLayers.ToArray();
         using var targetImage = target?.ToBitmap() ?? DrawUtility.CreateSizedCanvas(imagesCollection);
         DrawUtility.Draw(imagesCollection, targetImage);
-        return targetImage.ToImageFile(targetImage.RawFormat);
+        return Task.FromResult<IImageFile>(targetImage.ToImageFile(targetImage.RawFormat));
     }
 }

--- a/src/Drawing.SkiaSharp/Services/ImageService.cs
+++ b/src/Drawing.SkiaSharp/Services/ImageService.cs
@@ -20,21 +20,27 @@ namespace Regira.Drawing.SkiaSharp.Services;
 /// <remarks>
 /// This service is built on top of SkiaSharp and integrates with various abstractions and utilities for image manipulation.
 /// It supports multiple image formats and provides functionality for both memory-based and stream-based image operations.
+/// 
+/// All operations are exposed as <c>Task</c>-returning methods to enable async usage and cancellation, but the underlying
+/// SkiaSharp APIs are synchronous; the work is performed inline and wrapped via <see cref="Task.FromResult{T}"/>. Callers
+/// that need to offload work can do so with <see cref="Task.Run(System.Action)"/>.
 /// </remarks>
 public class ImageService : IImageService
 {
     /// <inheritdoc/>
-    public IImageFile? Parse(Stream? stream)
+    public Task<IImageFile?> Parse(Stream? stream, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (stream == null)
         {
-            return null;
+            return Task.FromResult<IImageFile?>(null);
         }
 
         using var bitmap = SKBitmap.Decode(stream);
         if (bitmap == null)
         {
-            return null;
+            return Task.FromResult<IImageFile?>(null);
         }
 
         var img = new ImageFile
@@ -42,21 +48,23 @@ public class ImageService : IImageService
             Stream = stream,
             Size = new[] { bitmap.Width, bitmap.Height }
         };
-        return img;
+        return Task.FromResult<IImageFile?>(img);
     }
     /// <inheritdoc/>
-    public IImageFile? Parse(byte[]? bytes)
+    public Task<IImageFile?> Parse(byte[]? bytes, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         if (bytes == null)
         {
-            return null;
+            return Task.FromResult<IImageFile?>(null);
         }
 
         using var ms = new MemoryStream(bytes);
         using var bitmap = SKBitmap.Decode(ms);
         if (bitmap == null)
         {
-            return null;
+            return Task.FromResult<IImageFile?>(null);
         }
 
         var img = new ImageFile
@@ -64,11 +72,13 @@ public class ImageService : IImageService
             Bytes = bytes,
             Size = new[] { bitmap.Width, bitmap.Height }
         };
-        return img;
+        return Task.FromResult<IImageFile?>(img);
     }
     /// <inheritdoc/>
-    public IImageFile? Parse(byte[] rawBytes, ImageSize size, ImageFormat? format = null)
+    public Task<IImageFile?> Parse(byte[] rawBytes, ImageSize size, ImageFormat? format = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         format ??= ImageFormat.Jpeg;
 
         using var skImg = SKImage.FromPixels(
@@ -79,17 +89,24 @@ public class ImageService : IImageService
         using var skBitmap = SKBitmap.FromImage(skImg);
         if (skBitmap == null)
         {
-            return null;
+            return Task.FromResult<IImageFile?>(null);
         }
 
         using var img = SkiaUtility.ChangeFormat(skBitmap, format.Value.ToSkiaFormat());
-        return img.ToImageFile(format.Value.ToSkiaFormat());
+        return Task.FromResult<IImageFile?>(img.ToImageFile(format.Value.ToSkiaFormat()));
     }
     /// <inheritdoc/>
-    public IImageFile? Parse(IMemoryFile file) => file.HasStream() ? Parse(file.Stream) : Parse(file.GetBytes());
+    public Task<IImageFile?> Parse(IMemoryFile file, CancellationToken cancellationToken = default) =>
+        file.HasStream() ? Parse(file.Stream, cancellationToken) : Parse(file.GetBytes(), cancellationToken);
 
     /// <inheritdoc/>
-    public ImageFormat GetFormat(IImageFile input)
+    public Task<ImageFormat> GetFormat(IImageFile input, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(GetFormatCore(input));
+    }
+
+    private static ImageFormat GetFormatCore(IImageFile input)
     {
         if (input.Stream != null && input.Stream != Stream.Null)
         {
@@ -105,91 +122,114 @@ public class ImageService : IImageService
         using var ms = new MemoryStream(bytes);
         return ConversionUtility.GetFormat(ms).ToImageFormat();
     }
+
     /// <inheritdoc/>
-    public IImageFile ChangeFormat(IImageFile input, ImageFormat targetFormat)
+    public Task<IImageFile> ChangeFormat(IImageFile input, ImageFormat targetFormat, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var skiaFormat = targetFormat.ToSkiaFormat();
         using var convertedBitmap = SkiaUtility.ChangeFormat(input.ToBitmap(), skiaFormat);
-        return convertedBitmap.ToImageFile(skiaFormat);
+        return Task.FromResult<IImageFile>(convertedBitmap.ToImageFile(skiaFormat));
     }
 
     /// <inheritdoc/>
-    public IImageFile CropRectangle(IImageFile input, ImageEdgeOffset rect)
+    public Task<IImageFile> CropRectangle(IImageFile input, ImageEdgeOffset rect, CancellationToken cancellationToken = default)
     {
-        var format = GetFormat(input);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var format = GetFormatCore(input);
         using var img = input.ToBitmap();
         var (topLeft, bottomRight) = DrawImageUtility.ToPoints(rect, new ImageSize(img.Width, img.Height));
         var skRect = new SKRect(topLeft.X, topLeft.Y, bottomRight.X, bottomRight.Y);
         using var croppedBitmap = SkiaUtility.CropRectangle(img, skRect);
-        return croppedBitmap.ToImageFile(format.ToSkiaFormat());
+        return Task.FromResult<IImageFile>(croppedBitmap.ToImageFile(format.ToSkiaFormat()));
     }
 
     /// <inheritdoc/>
-    public ImageSize GetDimensions(IImageFile input)
+    public Task<ImageSize> GetDimensions(IImageFile input, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = input.ToBitmap();
-        return new ImageSize(img.Width, img.Height);
+        return Task.FromResult(new ImageSize(img.Width, img.Height));
     }
     /// <inheritdoc/>
-    public IImageFile Resize(IImageFile input, ImageSize wantedSize, int quality = 80)
+    public Task<IImageFile> Resize(IImageFile input, ImageSize wantedSize, int quality = 80, CancellationToken cancellationToken = default)
     {
-        var format = GetFormat(input);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var format = GetFormatCore(input);
         using var sourceBitmap = input.ToBitmap();
         using var scaledBitmap = SkiaUtility.Resize(sourceBitmap, new SKSize(wantedSize.Width, wantedSize.Height), quality);
-        return scaledBitmap.ToImageFile(format.ToSkiaFormat());
+        return Task.FromResult<IImageFile>(scaledBitmap.ToImageFile(format.ToSkiaFormat()));
     }
     /// <inheritdoc/>
-    public IImageFile ResizeFixed(IImageFile input, ImageSize size, int quality = 80)
+    public Task<IImageFile> ResizeFixed(IImageFile input, ImageSize size, int quality = 80, CancellationToken cancellationToken = default)
     {
-        var format = GetFormat(input);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var format = GetFormatCore(input);
         using var sourceBitmap = input.ToBitmap();
         using var scaledBitmap = SkiaUtility.ResizeFixed(sourceBitmap, new SKSize(size.Width, size.Height), quality);
-        return scaledBitmap.ToImageFile(format.ToSkiaFormat());
+        return Task.FromResult<IImageFile>(scaledBitmap.ToImageFile(format.ToSkiaFormat()));
     }
 
     /// <inheritdoc/>
-    public IImageFile Rotate(IImageFile input, int degrees, Color? background = null)
+    public Task<IImageFile> Rotate(IImageFile input, int degrees, Color? background = null, CancellationToken cancellationToken = default)
     {
-        var format = GetFormat(input);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var format = GetFormatCore(input);
         using var sourceBitmap = input.ToBitmap();
         using var rotatedBitmap = SkiaUtility.Rotate(sourceBitmap, degrees, (background ?? Color.Transparent).ToSkiaColor());
-        return rotatedBitmap.ToImageFile(format.ToSkiaFormat());
+        return Task.FromResult<IImageFile>(rotatedBitmap.ToImageFile(format.ToSkiaFormat()));
     }
     /// <inheritdoc/>
-    public IImageFile FlipHorizontal(IImageFile input)
+    public Task<IImageFile> FlipHorizontal(IImageFile input, CancellationToken cancellationToken = default)
     {
-        var format = GetFormat(input);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var format = GetFormatCore(input);
         using var sourceBitmap = input.ToBitmap();
         using var flippedBitmap = SkiaUtility.FlipHorizontal(sourceBitmap);
-        return flippedBitmap.ToImageFile(format.ToSkiaFormat());
+        return Task.FromResult<IImageFile>(flippedBitmap.ToImageFile(format.ToSkiaFormat()));
     }
     /// <inheritdoc/>
-    public IImageFile FlipVertical(IImageFile input)
+    public Task<IImageFile> FlipVertical(IImageFile input, CancellationToken cancellationToken = default)
     {
-        var format = GetFormat(input);
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var format = GetFormatCore(input);
         using var sourceBitmap = input.ToBitmap();
         using var flippedBitmap = SkiaUtility.FlipVertical(sourceBitmap);
-        return flippedBitmap.ToImageFile(format.ToSkiaFormat());
+        return Task.FromResult<IImageFile>(flippedBitmap.ToImageFile(format.ToSkiaFormat()));
     }
 
     /// <inheritdoc/>
-    public Color GetPixelColor(IImageFile input, int x, int y)
+    public Task<Color> GetPixelColor(IImageFile input, int x, int y, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var image = input.ToBitmap();
-        return SkiaUtility.GetPixelColor(image, x, y).ToColor();
+        return Task.FromResult(SkiaUtility.GetPixelColor(image, x, y).ToColor());
     }
     /// <inheritdoc/>
-    public IImageFile MakeTransparent(IImageFile input, Color? color = null)
+    public Task<IImageFile> MakeTransparent(IImageFile input, Color? color = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         color ??= new Color(245, 245, 245);
         using var sourceBitmap = input.ToBitmap();
         var transparentBitmap = SkiaUtility.MakeTransparent(sourceBitmap, color.Value.ToSkiaColor());
         // return as PNG image
-        return transparentBitmap.ToImageFile();
+        return Task.FromResult<IImageFile>(transparentBitmap.ToImageFile());
     }
     /// <inheritdoc/>
-    public IImageFile MakeOpaque(IImageFile input)
+    public Task<IImageFile> MakeOpaque(IImageFile input, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var inputBitmap = input.ToBitmap();
 
         var outputBitmap = new SKBitmap(inputBitmap.Width, inputBitmap.Height);
@@ -200,6 +240,7 @@ public class ImageService : IImageService
 
         for (int x = 0; x < inputBitmap.Width; x++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             for (int y = 0; y < inputBitmap.Height; y++)
             {
                 var pixelColor = inputBitmap.GetPixel(x, y);
@@ -211,27 +252,33 @@ public class ImageService : IImageService
             }
         }
 
-        return outputBitmap.ToImageFile();
+        return Task.FromResult<IImageFile>(outputBitmap.ToImageFile());
     }
 
     /// <inheritdoc/>
-    public IImageFile Create(ImageSize size, Color? backgroundColor = null, ImageFormat? format = null)
+    public Task<IImageFile> Create(ImageSize size, Color? backgroundColor = null, ImageFormat? format = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = SkiaUtility.Create(size.ToSkiaSize(), (backgroundColor ?? ImageDefaults.BackgroundColor).ToSkiaColor());
-        return img.ToImageFile((format ?? ImageDefaults.Format).ToSkiaFormat());
+        return Task.FromResult<IImageFile>(img.ToImageFile((format ?? ImageDefaults.Format).ToSkiaFormat()));
     }
     /// <inheritdoc/>
-    public IImageFile CreateTextImage(LabelImageOptions? options = null)
+    public Task<IImageFile> CreateTextImage(LabelImageOptions? options = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         using var img = SkiaUtility.CreateTextImage(options);
-        return img.ToImageFile();
+        return Task.FromResult<IImageFile>(img.ToImageFile());
     }
     /// <inheritdoc/>
-    public IImageFile Draw(IEnumerable<ImageLayer> imageLayers, IImageFile? target = null)
+    public Task<IImageFile> Draw(IEnumerable<ImageLayer> imageLayers, IImageFile? target = null, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
+
         var imagesCollection = imageLayers.ToArray();
         using var targetImage = target?.ToBitmap() ?? DrawUtility.CreateSizedCanvas(imagesCollection);
         DrawUtility.Draw(imagesCollection, targetImage);
-        return targetImage.ToImageFile();
+        return Task.FromResult<IImageFile>(targetImage.ToImageFile());
     }
 }

--- a/src/Media.FFMpeg/SnapshotService.cs
+++ b/src/Media.FFMpeg/SnapshotService.cs
@@ -15,7 +15,7 @@ public class SnapshotService(IImageService imageService, IProcessHelper? process
 {
     readonly IProcessHelper _processHelper = processHelper ?? new ProcessHelper();
 
-    public async Task<IImageFile?> Snapshot(IBinaryFile input, ImageSize? size = null, TimeSpan? time = null)
+    public async Task<IImageFile?> Snapshot(IBinaryFile input, ImageSize? size = null, TimeSpan? time = null, CancellationToken cancellationToken = default)
     {
         var inputPath = input.GetPath();
         if (!size.HasValue || size.Value.Width == 0 || size.Value.Height == 0)
@@ -41,8 +41,8 @@ public class SnapshotService(IImageService imageService, IProcessHelper? process
         {
             throw new Exception("Empty file");
         }
-        using var jpeg = imageService.ChangeFormat(img, Drawing.Enums.ImageFormat.Jpeg);
-        var resized = imageService.Resize(jpeg, size.Value);
+        using var jpeg = await imageService.ChangeFormat(img, Drawing.Enums.ImageFormat.Jpeg, cancellationToken);
+        var resized = await imageService.Resize(jpeg, size.Value, cancellationToken: cancellationToken);
 
         File.Delete(tempPath);
 

--- a/src/PDF.DocNET/PdfManager.cs
+++ b/src/PDF.DocNET/PdfManager.cs
@@ -151,7 +151,7 @@ public class PdfManager(IImageService imageService) : IPdfService
     }
 
 
-    public Task<IMemoryFile?> ImagesToPdf(ImagesInput input, CancellationToken cancellationToken = default)
+    public async Task<IMemoryFile?> ImagesToPdf(ImagesInput input, CancellationToken cancellationToken = default)
     {
         if (imageService == null)
         {
@@ -163,26 +163,25 @@ public class PdfManager(IImageService imageService) : IPdfService
             (int)(input.MaxDimensions.Width - (input.Margins.Left + input.Margins.Right)),
             (int)(input.MaxDimensions.Height - (input.Margins.Top + input.Margins.Bottom))
         };
-        var jpegImages = input.Images
-            .Select(imgBytes =>
-                {
-                    var imageFile = imageService.Parse(imgBytes)!;
-                    var resized = imageService.Resize(imageFile, maxDim);
-                    var jpeg = imageService.ChangeFormat(resized, ImageFormat.Jpeg);
-                    return new JpegImage
-                    {
-                        Bytes = jpeg.Bytes,
-                        Width = jpeg.Size?.Width ?? 0,
-                        Height = jpeg.Size?.Height ?? 0
-                    };
-                }
-            )
-            .ToArray();
+        var jpegImages = new List<JpegImage>();
+        foreach (var imgBytes in input.Images)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            var imageFile = (await imageService.Parse(imgBytes, cancellationToken))!;
+            var resized = await imageService.Resize(imageFile, maxDim, cancellationToken: cancellationToken);
+            var jpeg = await imageService.ChangeFormat(resized, ImageFormat.Jpeg, cancellationToken);
+            jpegImages.Add(new JpegImage
+            {
+                Bytes = jpeg.Bytes,
+                Width = jpeg.Size?.Width ?? 0,
+                Height = jpeg.Size?.Height ?? 0
+            });
+        }
 
-        var pdfBytes = DocLib.Instance.JpegToPdf(jpegImages);
-        return Task.FromResult<IMemoryFile?>(pdfBytes.ToMemoryFile(ContentTypes.PDF));
+        var pdfBytes = DocLib.Instance.JpegToPdf(jpegImages.ToArray());
+        return pdfBytes.ToMemoryFile(ContentTypes.PDF);
     }
-    public Task<IEnumerable<IImageFile>> ToImages(IMemoryFile pdf, PdfToImagesOptions? options = null, CancellationToken cancellationToken = default)
+    public async Task<IEnumerable<IImageFile>> ToImages(IMemoryFile pdf, PdfToImagesOptions? options = null, CancellationToken cancellationToken = default)
     {
         var pageDimensions = new PageDimensions(
             options?.Size?.Width ?? PdfDefaults.ImageSize.Width,
@@ -194,14 +193,15 @@ public class PdfManager(IImageService imageService) : IPdfService
         var images = new List<IImageFile>(pageCount);
         for (var pageIndex = 0; pageIndex < pageCount; pageIndex++)
         {
+            cancellationToken.ThrowIfCancellationRequested();
             using var pr = docReader.GetPageReader(pageIndex);
             var imgBytes = pr.GetImage();
 
             var width = pr.GetPageWidth();
             var height = pr.GetPageHeight();
 
-            images.Add(imageService.Parse(imgBytes, new ImageSize(width, height), options?.Format)!);
+            images.Add((await imageService.Parse(imgBytes, new ImageSize(width, height), options?.Format, cancellationToken))!);
         }
-        return Task.FromResult<IEnumerable<IImageFile>>(images);
+        return images;
     }
 }

--- a/tests/Drawing.Testing/Abstractions/DrawingImageExtensions.cs
+++ b/tests/Drawing.Testing/Abstractions/DrawingImageExtensions.cs
@@ -11,14 +11,14 @@ public static class DrawingImageExtensions
     public static async Task Test_To_Png(this IImageService service, string filename)
     {
         using var image = await service.ReadImage(filename);
-        var pngImg = service.ChangeFormat(image, ImageFormat.Png);
+        var pngImg = await service.ChangeFormat(image, ImageFormat.Png);
 
         await service.SaveImage(pngImg, $"{Path.GetFileNameWithoutExtension(filename)}.png");
     }
     public static async Task Test_To_Jpeg(this IImageService service, string filename)
     {
         using var image = await service.ReadImage(filename);
-        var pngImg = service.ChangeFormat(image, ImageFormat.Jpeg);
+        var pngImg = await service.ChangeFormat(image, ImageFormat.Jpeg);
 
         await service.SaveImage(pngImg, $"{Path.GetFileNameWithoutExtension(filename)}.jpg");
     }
@@ -27,7 +27,7 @@ public static class DrawingImageExtensions
         using var image = await service.ReadImage(filename);
         var original = image.Size;
         var wantedSize = new ImageSize(1024, 1024);
-        using var resized = service.Resize(image, wantedSize, 60);
+        using var resized = await service.Resize(image, wantedSize, 60);
 
         await service.SaveImage(resized, $"{Path.GetFileNameWithoutExtension(filename)}-resized.jpg");
 
@@ -41,7 +41,7 @@ public static class DrawingImageExtensions
         using var image = await service.ReadImage(filename);
         var original = image.Size;
         var targetSize = new ImageSize(1024, 1024);
-        using var resized = service.ResizeFixed(image, targetSize);
+        using var resized = await service.ResizeFixed(image, targetSize);
 
         await service.SaveImage(resized, $"{Path.GetFileNameWithoutExtension(filename)}-resized-fixed.jpg");
 
@@ -53,7 +53,7 @@ public static class DrawingImageExtensions
     public static async Task Test_RotateImage90Right(this IImageService service)
     {
         using var image = await service.ReadImage("img-1.jpg");
-        using var rotatedR = service.Rotate(image, 90);
+        using var rotatedR = await service.Rotate(image, 90);
         Assert.That(rotatedR.Size!.Value.Height, Is.EqualTo(image.Size!.Value.Width));
         Assert.That(rotatedR.Size!.Value.Width, Is.EqualTo(image.Size!.Value.Height));
 
@@ -64,7 +64,7 @@ public static class DrawingImageExtensions
     public static async Task Test_RotateImage90Left(this IImageService service)
     {
         using var image = await service.ReadImage("img-1.jpg");
-        using var rotatedL = service.Rotate(image, -90);
+        using var rotatedL = await service.Rotate(image, -90);
         Assert.That(rotatedL.Size!.Value.Height, Is.EqualTo(image.Size!.Value.Width));
         Assert.That(rotatedL.Size!.Value.Width, Is.EqualTo(image.Size!.Value.Height));
 
@@ -89,7 +89,7 @@ public static class DrawingImageExtensions
 
         foreach (var rectangle in rectangles)
         {
-            using var cropped = service.CropRectangle(image, rectangle.Value);
+            using var cropped = await service.CropRectangle(image, rectangle.Value);
             await service.SaveImage(cropped, $"{Path.GetFileNameWithoutExtension(filename)}-{rectangle.Key}{Path.GetExtension(filename)}");
         }
     }
@@ -97,14 +97,14 @@ public static class DrawingImageExtensions
     {
         using var image = await service.ReadImage(filename);
 
-        using var rgbImg = service.MakeTransparent(image, new Color(200, 200, 200));
+        using var rgbImg = await service.MakeTransparent(image, new Color(200, 200, 200));
         await service.SaveImage(rgbImg, $"{Path.GetFileNameWithoutExtension(filename)}-transparent.png");
     }
     public static async Task Test_MakeOpaque(this IImageService service, string filename)
     {
         using var image = await service.ReadImage(filename);
 
-        using var rgbImg = service.MakeOpaque(image);
+        using var rgbImg = await service.MakeOpaque(image);
         await service.SaveImage(rgbImg, $"{Path.GetFileNameWithoutExtension(filename)}-rgb.png");
     }
 }

--- a/tests/Drawing.Testing/Extensions/DrawingPositionExtensions.cs
+++ b/tests/Drawing.Testing/Extensions/DrawingPositionExtensions.cs
@@ -16,13 +16,13 @@ public static class DrawingPositionExtensions
             Source = await service.ReadImage("yellow-200x150.jpg")
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-no-params.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 190, 140));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 210, 150));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 200, 160));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 190, 140));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 210, 150));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 200, 160));
     }
 
     // Positioned
@@ -38,13 +38,13 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-top-left.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 190, 140));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 210, 150));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 200, 160));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 190, 140));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 210, 150));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 200, 160));
     }
     public static async Task AddImage_Bottom_Left(this IImageService service)
     {
@@ -58,13 +58,13 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-bottom-left.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 10, 160));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 190, 290));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 210, 290));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 10, 160));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 190, 290));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 210, 290));
     }
     public static async Task AddImage_Top_Right(this IImageService service)
     {
@@ -78,14 +78,14 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-top-right.jpg");
 
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 360, 10));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 390, 90));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 340, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 360, 110));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 360, 10));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 390, 90));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 340, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 360, 110));
     }
     public static async Task AddImage_Bottom_Right(this IImageService service)
     {
@@ -99,15 +99,15 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-bottom-right.jpg");
 
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 360, 210));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 390, 290));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 290));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 390, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 390, 190));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 360, 210));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 390, 290));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 290));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 390, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 390, 190));
     }
 
     // Centered
@@ -123,14 +123,14 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-top-hcenter.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 110, 10));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 290, 140));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 290));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 200, 160));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 110, 10));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 290, 140));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 290));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 200, 160));
     }
     public static async Task AddImage_Bottom_HCenter(this IImageService service)
     {
@@ -144,15 +144,15 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-bottom-hcenter.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 110, 160));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 290, 290));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 290));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 90, 290));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 310, 290));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 110, 160));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 290, 290));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 290));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 90, 290));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 310, 290));
     }
     public static async Task AddImage_Left_VCenter(this IImageService service)
     {
@@ -166,15 +166,15 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-right-vcenter.jpg");
 
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 10, 110));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 10, 190));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 90));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 60, 150));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 290));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 10, 110));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 10, 190));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 90));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 60, 150));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 290));
     }
     public static async Task AddImage_Right_VCenter(this IImageService service)
     {
@@ -188,15 +188,15 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-right-vcenter.jpg");
 
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 360, 110));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 390, 190));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 390, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 340, 150));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 390, 290));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 360, 110));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 390, 190));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 390, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 340, 150));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 390, 290));
     }
     public static async Task AddImage_Middle(this IImageService service)
     {
@@ -210,18 +210,18 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-middle.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 110, 85));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 200, 150));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 290, 175));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 150));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 290));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 200));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 90, 150));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 310, 150));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 110, 85));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 200, 150));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 290, 175));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 150));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 290));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 200));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 90, 150));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 310, 150));
     }
 
     // Absolute
@@ -238,15 +238,15 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-abs-top-left.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 80, 80)); // GDI causes problems when checking (60, 60)
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 240, 190));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 40, 40));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 260, 210));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 390, 290));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 80, 80)); // GDI causes problems when checking (60, 60)
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 240, 190));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 40, 40));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 260, 210));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 390, 290));
     }
     public static async Task AddImage_Absolute_Top_Right(this IImageService service)
     {
@@ -261,15 +261,15 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-abs-top-right.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 160, 60));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 240, 190));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 140, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 140, 60));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 360, 60));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 360, 190));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 160, 60));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 240, 190));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 140, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 140, 60));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 360, 60));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 360, 190));
     }
     public static async Task AddImage_Absolute_Bottom_Left(this IImageService service)
     {
@@ -284,13 +284,13 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-abs-bottom-left.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 60, 160));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 240, 240));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 40, 140));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 260, 260));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 60, 160));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 240, 240));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 40, 140));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 260, 260));
     }
     public static async Task AddImage_Absolute_Bottom_Right(this IImageService service)
     {
@@ -305,13 +305,13 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-abs-bottom-right.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 160, 160));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 240, 240));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 140, 140));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 360, 260));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 160, 160));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 240, 240));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 140, 140));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 360, 260));
     }
 
     // Margins
@@ -327,13 +327,13 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-margin10.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 20, 20));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 190, 140));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 1, 1));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 220, 170));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 20, 20));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 190, 140));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 1, 1));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 220, 170));
     }
     public static async Task AddImage_Top_Left_Margin10(this IImageService service)
     {
@@ -348,14 +348,14 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-top-left-margin10.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 20, 20));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 190, 140));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 1, 1));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 220, 170));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 220, 170));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 20, 20));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 190, 140));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 1, 1));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 220, 170));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 220, 170));
     }
     public static async Task AddImage_Bottom_Left_Margin10(this IImageService service)
     {
@@ -370,14 +370,14 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-bottom-left-margin10.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 20, 150));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 200, 280));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 130));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 220, 290));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 0, 299));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 20, 150));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 200, 280));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 130));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 220, 290));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 0, 299));
     }
     public static async Task AddImage_Top_Right_Margin10(this IImageService service)
     {
@@ -392,15 +392,15 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-top-right-margin10.jpg");
 
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 350, 20));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 380, 100));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 330, 20));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 380, 120));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 399, 0));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 350, 20));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 380, 100));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 330, 20));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 380, 120));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 399, 0));
     }
     public static async Task AddImage_Bottom_Right_Margin10(this IImageService service)
     {
@@ -415,15 +415,15 @@ public static class DrawingPositionExtensions
             }
         };
 
-        using var resultImg = service.Draw([imgToAdd], target);
+        using var resultImg = await service.Draw([imgToAdd], target);
         await service.SaveImage(resultImg, "add-image-bottom-right-margin10.jpg");
 
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 350, 200));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 380, 280));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 280));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 330, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 380, 180));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 399, 299));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 350, 200));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 380, 280));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 280));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 330, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 380, 180));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 399, 299));
     }
 }

--- a/tests/Drawing.Testing/Extensions/DrawingTestHelpExtensions.cs
+++ b/tests/Drawing.Testing/Extensions/DrawingTestHelpExtensions.cs
@@ -19,37 +19,37 @@ public static class DrawingTestHelpExtensions
         var transparentPath = Path.Combine(inputDir, "transparent-400x300.jpg");
         if (!File.Exists(transparentPath))
         {
-            using var img = service.Create(new ImageSize(400, 300), null, ImageFormat.Png);
+            using var img = await service.Create(new ImageSize(400, 300), null, ImageFormat.Png);
             await img.SaveAs(transparentPath);
         }
         var whitePath = Path.Combine(inputDir, "white-400x300.jpg");
         if (!File.Exists(whitePath))
         {
-            using var img = service.Create(new ImageSize(400, 300), "#FFFFFF", ImageFormat.Jpeg);
+            using var img = await service.Create(new ImageSize(400, 300), "#FFFFFF", ImageFormat.Jpeg);
             await img.SaveAs(whitePath);
         }
         var yellowPath = Path.Combine(inputDir, "yellow-200x150.jpg");
         if (!File.Exists(yellowPath))
         {
-            using var img = service.Create(new ImageSize(200, 150), "#FFFF00", ImageFormat.Jpeg);
+            using var img = await service.Create(new ImageSize(200, 150), "#FFFF00", ImageFormat.Jpeg);
             await img.SaveAs(yellowPath);
         }
         var redPath = Path.Combine(inputDir, "red-150x100.jpg");
         if (!File.Exists(redPath))
         {
-            using var img = service.Create(new ImageSize(150, 100), "#FF0000", ImageFormat.Jpeg);
+            using var img = await service.Create(new ImageSize(150, 100), "#FF0000", ImageFormat.Jpeg);
             await img.SaveAs(redPath);
         }
         var greenPath = Path.Combine(inputDir, "green-50x100.jpg");
         if (!File.Exists(greenPath))
         {
-            using var img = service.Create(new ImageSize(50, 100), "#00FF00", ImageFormat.Jpeg);
+            using var img = await service.Create(new ImageSize(50, 100), "#00FF00", ImageFormat.Jpeg);
             await img.SaveAs(greenPath);
         }
         var bluePath = Path.Combine(inputDir, "blue-50x50.jpg");
         if (!File.Exists(bluePath))
         {
-            using var img = service.Create(new ImageSize(50, 50), "#0000FF", ImageFormat.Jpeg);
+            using var img = await service.Create(new ImageSize(50, 50), "#0000FF", ImageFormat.Jpeg);
             await img.SaveAs(bluePath);
         }
     }
@@ -73,7 +73,7 @@ public static class DrawingTestHelpExtensions
         var bytes = await File.ReadAllBytesAsync(path);
 
         var img = bytes.ToBinaryFile().ToImageFile();
-        img.Size = service.GetDimensions(img);
+        img.Size = await service.GetDimensions(img);
         return img;
     }
     internal static Task<string?> ReadImageText(this IImageFile img)

--- a/tests/Drawing.Testing/Extensions/DrawingTextExtensions.cs
+++ b/tests/Drawing.Testing/Extensions/DrawingTextExtensions.cs
@@ -9,7 +9,7 @@ public static class DrawingTextExtensions
     public static async Task Add_Text_No_Params(this IImageService service)
     {
         var input = "Hello World!";
-        using var testImage = service.CreateTextImage(input);
+        using var testImage = await service.CreateTextImage(input);
 
         await service.SaveImage(testImage, "hello-world.png");
         Assert.That(testImage.Format, Is.EqualTo(ImageFormat.Png));
@@ -17,13 +17,13 @@ public static class DrawingTextExtensions
         var content = await testImage.ReadImageText();
 
         Assert.That(content, Is.EqualTo(input));
-        DrawingTestHelpExtensions.AssertColor("#FFFFFF", service.GetPixelColor(testImage, 1, 1));
+        DrawingTestHelpExtensions.AssertColor("#FFFFFF", await service.GetPixelColor(testImage, 1, 1));
     }
 
     public static async Task Add_Text_With_Options(this IImageService service)
     {
         var input = "Hello World!";
-        using var testImage = service.CreateTextImage(new LabelImageOptions
+        using var testImage = await service.CreateTextImage(new LabelImageOptions
         {
             Text = input,
             FontSize = 25,
@@ -38,13 +38,13 @@ public static class DrawingTextExtensions
         var content = await testImage.ReadImageText();
 
         Assert.That(content, Is.EqualTo(input));
-        DrawingTestHelpExtensions.AssertColor("#FFFF00", service.GetPixelColor(testImage, 1, 1));
+        DrawingTestHelpExtensions.AssertColor("#FFFF00", await service.GetPixelColor(testImage, 1, 1));
     }
 
     public static async Task Add_Text_With_Margin(this IImageService service)
     {
         var input = "Hello World!";
-        using var testImage = service.CreateTextImage(new LabelImageOptions
+        using var testImage = await service.CreateTextImage(new LabelImageOptions
         {
             Text = input,
             FontSize = 25,
@@ -57,6 +57,6 @@ public static class DrawingTextExtensions
         Assert.That(testImage.Format, Is.EqualTo(ImageFormat.Png));
         var content = await testImage.ReadImageText();
         Assert.That(content, Is.EqualTo(input));
-        DrawingTestHelpExtensions.AssertColor("#FFFF00", service.GetPixelColor(testImage, 1, 1));
+        DrawingTestHelpExtensions.AssertColor("#FFFF00", await service.GetPixelColor(testImage, 1, 1));
     }
 }

--- a/tests/Drawing.Testing/Extensions/ImageBuilderExtensions.cs
+++ b/tests/Drawing.Testing/Extensions/ImageBuilderExtensions.cs
@@ -43,18 +43,18 @@ public static class ImageBuilderExtensions
         };
 
         var drawBuilder = new ImageBuilder(service, []);
-        using var resultImg = drawBuilder
+        using var resultImg = await drawBuilder
             .Add(imageLayers)
             .Build();
         await service.SaveImage(resultImg, "build-no-target.jpg");
 
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 10, 10), new[] { 10, 10 });
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 150, 100), new[] { 290, 60 });
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 290, 90), new[] { 290, 60 });
-        AssertColor("#0000FF", service.GetPixelColor(resultImg, 290, 10), new[] { 290, 10 });
-        AssertColor("#0000FF", service.GetPixelColor(resultImg, 260, 40), new[] { 260, 40 });
-        AssertColor("#FF0000", service.GetPixelColor(resultImg, 10, 160), new[] { 10, 160 });
-        AssertColor("#FF0000", service.GetPixelColor(resultImg, 90, 190), new[] { 90, 190 });
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 10, 10), new[] { 10, 10 });
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 150, 100), new[] { 290, 60 });
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 290, 90), new[] { 290, 60 });
+        AssertColor("#0000FF", await service.GetPixelColor(resultImg, 290, 10), new[] { 290, 10 });
+        AssertColor("#0000FF", await service.GetPixelColor(resultImg, 260, 40), new[] { 260, 40 });
+        AssertColor("#FF0000", await service.GetPixelColor(resultImg, 10, 160), new[] { 10, 160 });
+        AssertColor("#FF0000", await service.GetPixelColor(resultImg, 90, 190), new[] { 90, 190 });
     }
 
     public static async Task Build_WithTargetCanvas(this IImageService service)
@@ -110,21 +110,21 @@ public static class ImageBuilderExtensions
 
 
         var drawBuilder = new ImageBuilder(service, imageCreators);
-        using var resultImg = drawBuilder.Add(imageLayers)
+        using var resultImg = await drawBuilder.Add(imageLayers)
             .SetBaseLayer(target)
             .Build();
         await service.SaveImage(resultImg, "build-with-canvas.jpg");
 
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 150, 299));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 390, 10));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 360, 90));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 45, 35));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 330, 35));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 45, 160));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 350, 260));
-        AssertColor("#FF0000", service.GetPixelColor(resultImg, 20, 270));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 399, 299));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 150, 299));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 390, 10));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 360, 90));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 45, 35));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 330, 35));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 45, 160));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 350, 260));
+        AssertColor("#FF0000", await service.GetPixelColor(resultImg, 20, 270));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 399, 299));
     }
     public static async Task Build_WithTargetImage(this IImageService service)
     {
@@ -176,22 +176,22 @@ public static class ImageBuilderExtensions
 
 
         var drawBuilder = new ImageBuilder(service, imageCreators);
-        using var resultImg = drawBuilder
+        using var resultImg = await drawBuilder
             .SetBaseLayer(target)
             .Add(imageLayers)
             .Build();
         await service.SaveImage(resultImg, "build-with-target.jpg");
 
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 150, 299));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 390, 10));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 360, 90));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 45, 35));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 330, 35));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 45, 160));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 350, 260));
-        AssertColor("#FF0000", service.GetPixelColor(resultImg, 20, 270));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 399, 299));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 150, 299));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 390, 10));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 360, 90));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 45, 35));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 330, 35));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 45, 160));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 350, 260));
+        AssertColor("#FF0000", await service.GetPixelColor(resultImg, 20, 270));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 399, 299));
     }
 
     public static async Task Build_Images(this IImageService service)
@@ -260,22 +260,22 @@ public static class ImageBuilderExtensions
 
 
         var drawBuilder = new ImageBuilder(service, imageCreators);
-        using var resultImg = drawBuilder
+        using var resultImg = await drawBuilder
             .SetBaseLayer(target)
             .Add(imageLayers)
             .Build();
         await service.SaveImage(resultImg, "build-images.jpg");
 
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 10, 10));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 150, 299));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 390, 10));
-        AssertColor("#00FF00", service.GetPixelColor(resultImg, 360, 90));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 45, 35));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 330, 35));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 45, 160));
-        AssertColor("#FFFF00", service.GetPixelColor(resultImg, 350, 260));
-        //AssertColor("#FFFF00", service.GetPixelColor(resultImg, 200, 150));
-        AssertColor("#FF0000", service.GetPixelColor(resultImg, 20, 270));
-        AssertColor("#FFFFFF", service.GetPixelColor(resultImg, 399, 299));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 10, 10));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 150, 299));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 390, 10));
+        AssertColor("#00FF00", await service.GetPixelColor(resultImg, 360, 90));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 45, 35));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 330, 35));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 45, 160));
+        AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 350, 260));
+        //AssertColor("#FFFF00", await service.GetPixelColor(resultImg, 200, 150));
+        AssertColor("#FF0000", await service.GetPixelColor(resultImg, 20, 270));
+        AssertColor("#FFFFFF", await service.GetPixelColor(resultImg, 399, 299));
     }
 }


### PR DESCRIPTION
Refactors IImageService and IImageCreator to expose async, cancellable APIs throughout the codebase.

API changes (BREAKING):
- All 19 IImageService methods now return Task<T> and accept an optional CancellationToken (last parameter, defaults to default).
- IImageCreator.Create -> Task<IImageFile?> Create(object, CT). CanCreate stays synchronous.
- ImageBuilder.Build -> Task<IImageFile> Build(CT).
- DrawImageUtility extension methods (Create<T>, GetImageFile) return Task<IImageFile?> and accept CT.
- Method names are unchanged (no Async suffix), matching the existing convention elsewhere in the codebase (e.g. SnapshotService.Snapshot, PdfManager.ImagesToPdf).

Implementation pattern:
- Image processing is CPU-bound. Implementations call cancellationToken.ThrowIfCancellationRequested() at the top, perform the existing synchronous work inline, and wrap the result with Task.FromResult. No forced thread-pool offload -- callers wanting that can wrap with Task.Run.
- SkiaSharp MakeOpaque additionally checks the token on each outer pixel-loop iteration so long-running ops are interruptible.

Files touched (24):
- 5 sub-interfaces in Common.Media (Parsing, Format, Transform, Color, Draw)
- IImageCreator + ImageCreatorBase
- Drawing.SkiaSharp.ImageService, Drawing.GDI.ImageService
- Common.Media: ImageBuilder, AggregateImageCreator, CanvasImageCreator, LabelImageCreator, DrawImageUtility
- Common.Office image creators (Barcode/Pdf/Word) -- now naturally async, replacing previous .GetAwaiter().GetResult() calls
- Media.FFMpeg.SnapshotService, PDF.DocNET.PdfManager
- 5 test extension files in Drawing.Testing

Notes:
- Markdown docs (ai/*.md, src/Common.Media/README.md and docs/examples.md) still show the old sync API and should be updated in a follow-up.
- No compile verification performed (no .NET SDK available in the authoring environment).